### PR TITLE
Fix login bug by uncommenting UserConnectionService

### DIFF
--- a/src/Service/UserConnectionService.php
+++ b/src/Service/UserConnectionService.php
@@ -49,12 +49,12 @@ class UserConnectionService
         // Check if the user exists in the database
         $user = $this->db->getUserByEmail($email);
 
-        // if ($user && Security::verifyPassword($password, $user->getPassword())) {
-        // Save the user to a cookie
-        $user = serialize($user);
-        Cookies::set('user', $user);
-        return true;
-        // }
+        if ($user && Security::verifyPassword($password, $user->getPassword())) {
+            // Save the user to a cookie
+            $user = serialize($user);
+            Cookies::set('user', $user);
+            return true;
+        }
 
         // Delete the user cookie if the login is unsuccessful
         Cookies::delete('user');


### PR DESCRIPTION
This pull request fixes a login bug by uncommenting the UserConnectionService code that was previously commented out. This change ensures that the user's password is verified and the user is saved to a cookie only if the verification is successful.