### PR TITLE
Remove search feature from admin header

### DIFF
--- a/template/header/admin_header.html.twig
+++ b/template/header/admin_header.html.twig
@@ -9,12 +9,6 @@
             <li class="liheader"><a href="/admin/users">Gestion Utilisateurs</a></li>
             <li class="liheader"><a href="/profil">Profil</a></li>
             <li class="liheader"><a href="/deconnexion">Deconnexion</a></li>
-            <li class="liheader">
-                <form action="/search" method="GET">
-                    <input type="text" name="query" placeholder="Search" class="search-input">
-                    <button type="submit" class="search-button">Search</button>
-                </form>
-            </li>
         </ul>
     </nav>
 </header>


### PR DESCRIPTION
This pull request removes the search feature from the admin header. The search functionality was deemed unnecessary and has been removed to simplify the header design.